### PR TITLE
feat(api): implement image upload endpoint for prediction pipeline

### DIFF
--- a/tamatar_backend/api/urls.py
+++ b/tamatar_backend/api/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
-from .views import hello_world
+from .views import predict
 
 urlpatterns = [
-    path('hello/', hello_world),
+    path('predict/', predict),
 ]

--- a/tamatar_backend/api/views.py
+++ b/tamatar_backend/api/views.py
@@ -1,6 +1,82 @@
+import os
+import uuid
+from PIL import Image, UnidentifiedImageError
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
+from rest_framework import status
+from django.conf import settings
+from django.core.files.storage import default_storage
 
-@api_view(['GET'])
-def hello_world(request):
-    return Response({"message": "Welcome to Tamatar backend"})
+ALLOWED_EXTENSIONS = ['.jpg', '.jpeg', '.png']
+
+def is_valid_image(file):
+    """Validate uploaded file is an image.
+
+    This checks both the file extension and attempts to open/verify
+    the file using Pillow. If Pillow cannot identify or verify the
+    image, the function returns False.
+    """
+    ext = os.path.splitext(file.name)[1].lower()
+    if ext not in ALLOWED_EXTENSIONS:
+        return False
+
+    try:
+        img = Image.open(file)
+        img.verify()
+    except (UnidentifiedImageError, OSError):
+        return False
+    finally:
+        try:
+            file.seek(0)
+        except Exception:
+            pass
+
+    return True
+
+
+@api_view(['POST'])
+def predict(request):
+    if 'image' not in request.FILES:
+        return Response(
+            {"error": "No image provided"},
+            status=status.HTTP_400_BAD_REQUEST
+        )
+
+    image = request.FILES['image']
+
+    default_limit = 5 * 1024 * 1024 # 5 MB max upload
+    max_size = getattr(settings, 'MAX_IMAGE_UPLOAD_SIZE', None)
+    if max_size is None:
+        max_size = getattr(settings, 'FILE_UPLOAD_MAX_MEMORY_SIZE', None) or default_limit
+
+    if image.size > max_size:
+        return Response(
+            {"error": "Uploaded file is too large", "max_size_bytes": max_size},
+            status=status.HTTP_400_BAD_REQUEST
+        )
+    
+    # Validate file type
+    if not is_valid_image(image):
+        return Response(
+            {"error": "Invalid file type. Only JPG, JPEG, PNG allowed"},
+            status=status.HTTP_400_BAD_REQUEST
+        )
+
+    # Save temporarily
+    ext = os.path.splitext(image.name)[1].lower()
+    safe_name = f"{uuid.uuid4().hex}{ext}"
+    file_path = default_storage.save(os.path.join('temp', safe_name), image)
+
+    try:
+        public_url = default_storage.url(file_path)
+    except Exception:
+        public_url = None
+
+    response_data = {
+        "message": "Image uploaded successfully",
+        "file_path": file_path
+    }
+    if public_url:
+        response_data["url"] = public_url
+
+    return Response(response_data, status=status.HTTP_200_OK)

--- a/tamatar_backend/requirements.txt
+++ b/tamatar_backend/requirements.txt
@@ -2,4 +2,5 @@ asgiref==3.11.1
 Django==5.2.13
 django-cors-headers==4.9.0
 djangorestframework==3.17.1
+pillow==12.2.0
 sqlparse==0.5.5

--- a/tamatar_backend/tamatar_backend/settings.py
+++ b/tamatar_backend/tamatar_backend/settings.py
@@ -11,10 +11,12 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
 from pathlib import Path
-
+import os
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+MEDIA_URL = '/media/'
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
@@ -30,7 +32,6 @@ ALLOWED_HOSTS = []
 CORS_ALLOW_ALL_ORIGINS = True
 
 # Application definition
-
 INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',


### PR DESCRIPTION
## Overview
This PR adds a backend API endpoint to handle image uploads from the frontend for tomato leaf disease prediction.

Fixes: #10 

## Features
- Implemented POST `/api/predict/` endpoint
- Accepts image uploads via `multipart/form-data`
- Validates file types (JPG, JPEG, PNG)
- Temporarily stores uploaded images in `media/temp/`
- Returns a success response after upload